### PR TITLE
Fix Redundant Sort Order Name

### DIFF
--- a/pkg/sortx/sortx.go
+++ b/pkg/sortx/sortx.go
@@ -8,8 +8,8 @@ type (
 )
 
 const (
-	SortOrderAscending Order = iota + 1
-	SortOrderDescending
+	OrderAscending Order = iota + 1
+	OrderDescending
 )
 
 type Sort struct {
@@ -29,16 +29,16 @@ func NewSorts(qs string) []Sort {
 
 		s := Sort{
 			Key:   Key(kv[0]),
-			Order: SortOrderAscending,
+			Order: OrderAscending,
 		}
 		if len(kv) == 2 {
 			switch kv[1] {
 			case "asc":
-				s.Order = SortOrderAscending
+				s.Order = OrderAscending
 			case "desc":
-				s.Order = SortOrderDescending
+				s.Order = OrderDescending
 			default:
-				s.Order = SortOrderAscending
+				s.Order = OrderAscending
 			}
 		}
 		res = append(res, s)

--- a/pkg/sortx/sortx_test.go
+++ b/pkg/sortx/sortx_test.go
@@ -22,15 +22,15 @@ func TestNewSorts(t *testing.T) {
 			want: []Sort{
 				{
 					Key:   "id",
-					Order: SortOrderDescending,
+					Order: OrderDescending,
 				},
 				{
 					Key:   "status",
-					Order: SortOrderAscending,
+					Order: OrderAscending,
 				},
 				{
 					Key:   "created_at",
-					Order: SortOrderAscending,
+					Order: OrderAscending,
 				},
 			},
 		},


### PR DESCRIPTION
Instead of `sortx.SortOrder`, it's better to type `sortx.Order`.